### PR TITLE
Fix email validation in send_bulk emails

### DIFF
--- a/lib/bento/resources/emails.rb
+++ b/lib/bento/resources/emails.rb
@@ -36,7 +36,7 @@ module Bento
 
       def send_bulk(emails)
         raise ArgumentError, 'Emails must be an array' unless emails.is_a?(Array)
-        emails.each { |email| validate_email(email) }
+        emails.each { |email| validate_email(email[:to]); validate_email(email[:from]) }
 
         payload = { emails: emails }.to_json
         response = client.post("api/v1/batch/emails?#{URI.encode_www_form(default_params)}", payload)


### PR DESCRIPTION
While going through the code, I found potentially a bug in email validations. 

Here is a snippet of the code in `lib/bento/resources/emails.rb`:
```
     def send_transactional(to:, from:, subject:, html_body:, personalizations: {})
        validate_email(to)
        validate_author(from)

        payload = {
          to: to,
          from: from,
          subject: subject,
          html_body: html_body,
          personalizations: personalizations,
          transactional: true
        }

        send_bulk([payload])
     end

      def send_bulk(emails)
        raise ArgumentError, 'Emails must be an array' unless emails.is_a?(Array)
        emails.each { |email| validate_email(email) }

        payload = { emails: emails }.to_json
        response = client.post("api/v1/batch/emails?#{URI.encode_www_form(default_params)}", payload)
        Bento::Response.new(response)
      end
```

The `send_email` or `send_transactional` method at the end calls `send_bulk([payload])`. The `payload` here is a json object and not an email string.

Now  in `send_bulk(emails)` method, there is this line: `emails.each { |email| validate_email(email) }` 

The problem is that `email` object here is a payload object i.e a hash and not an email string. So ideally we need to fetch the `email` from the payload and pass that. So I am fetching `email[:to] and email[:from]` to run the validation on.

It does not fail right now as the validator looks like this:
```
def validate_email(email)
   raise ArgumentError, 'Email is required' if email.nil? || email.empty?
end
``` 

If we were checking for email pattern using a regex like it is done in the `events.rb` resource, it would have failed. But a fix is needed nonetheless if I have understood the whole flow here correctly.

I will be creating a different PR to clean up the whole validation logic as there should not be 2 different email validation methods in the codebase.