### PR TITLE
Added Validators

### DIFF
--- a/lib/bento-sdk.rb
+++ b/lib/bento-sdk.rb
@@ -3,6 +3,9 @@ require "bento/core/client"
 require "bento/core/error"
 require "bento/core/response"
 require "bento/core/version"
+require "bento/core/validators/base"
+require "bento/core/validators/event_validators"
+require "bento/core/validators/email_validators"
 require "bento/resources/subscribers"
 require "bento/resources/events"
 require "bento/resources/emails"
@@ -41,7 +44,7 @@ module Bento
 
   class << self
     extend Forwardable
-    
+
     # User configurable options
     def_delegators :@config, :site_uuid, :site_uuid=
     def_delegators :@config, :publishable_key, :publishable_key=

--- a/lib/bento/core/validators/base.rb
+++ b/lib/bento/core/validators/base.rb
@@ -1,0 +1,18 @@
+module Bento
+  module Validators
+    module Base
+      def validate_email(email)
+        raise ArgumentError, 'Email is required' if email.nil? || email.empty?
+        raise ArgumentError, 'Invalid email format' unless email =~ /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
+      end
+
+      def validate_type(type)
+        raise ArgumentError, 'Type is required' if type.nil? || type.empty?
+      end
+
+      def validate_fields(fields)
+        raise ArgumentError, 'Fields must be a hash' unless fields.is_a?(Hash)
+      end
+    end
+  end
+end

--- a/lib/bento/core/validators/email_validators.rb
+++ b/lib/bento/core/validators/email_validators.rb
@@ -1,0 +1,10 @@
+module Bento
+  module Validators
+    module EmailValidators
+      def validate_author(author)
+        raise ArgumentError, 'Author is required' if author.nil? || author.empty?
+        # Additional validation can be implemented based on system requirements
+      end
+    end
+  end
+end

--- a/lib/bento/core/validators/event_validators.rb
+++ b/lib/bento/core/validators/event_validators.rb
@@ -1,0 +1,46 @@
+module Bento
+  module Validators
+    module EventValidators
+      ef validate_details(details)
+        raise ArgumentError, 'Details must be a hash' unless details.is_a?(Hash)
+        validate_unique(details[:unique]) if details.key?(:unique)
+        validate_value(details[:value]) if details.key?(:value)
+        validate_cart(details[:cart]) if details.key?(:cart)
+      end
+
+      def validate_unique(unique)
+        raise ArgumentError, 'Unique must be a hash' unless unique.is_a?(Hash)
+        raise ArgumentError, 'Unique key is required' unless unique.key?(:key)
+      end
+
+      def validate_value(value)
+        raise ArgumentError, 'Value must be a hash' unless value.is_a?(Hash)
+        raise ArgumentError, 'Currency is required in value' unless value.key?(:currency)
+        raise ArgumentError, 'Amount is required in value' unless value.key?(:amount)
+      end
+
+      def validate_cart(cart)
+        raise ArgumentError, 'Cart must be a hash' unless cart.is_a?(Hash)
+        validate_cart_items(cart[:items]) if cart.key?(:items)
+      end
+
+      def validate_cart_items(items)
+        raise ArgumentError, 'Cart items must be an array' unless items.is_a?(Array)
+        items.each do |item|
+          raise ArgumentError, 'Cart item must be a hash' unless item.is_a?(Hash)
+          raise ArgumentError, 'Product SKU is required in cart item' unless item.key?(:product_sku)
+          raise ArgumentError, 'Product name is required in cart item' unless item.key?(:product_name)
+          raise ArgumentError, 'Quantity is required in cart item' unless item.key?(:quantity)
+        end
+      end
+
+      def validate_event(event)
+        raise ArgumentError, 'Event must be a hash' unless event.is_a?(Hash)
+        validate_email(event[:email])
+        validate_type(event[:type])
+        validate_fields(event[:fields]) if event.key?(:fields)
+        validate_details(event[:details]) if event.key?(:details)
+      end
+    end
+  end
+end

--- a/lib/bento/core/validators/event_validators.rb
+++ b/lib/bento/core/validators/event_validators.rb
@@ -1,7 +1,7 @@
 module Bento
   module Validators
     module EventValidators
-      ef validate_details(details)
+      def validate_details(details)
         raise ArgumentError, 'Details must be a hash' unless details.is_a?(Hash)
         validate_unique(details[:unique]) if details.key?(:unique)
         validate_value(details[:value]) if details.key?(:value)

--- a/lib/bento/resources/emails.rb
+++ b/lib/bento/resources/emails.rb
@@ -1,6 +1,8 @@
 module Bento
   class Emails
     class << self
+      include Bento::Validators::Base
+      include Bento::Validators::EmailValidators
       # Send an email that honors subscription status
       def send(to:, from:, subject:, html_body:, personalizations: {})
         validate_email(to)
@@ -43,7 +45,6 @@ module Bento
         Bento::Response.new(response)
       end
 
-
       private
 
       def client
@@ -52,15 +53,6 @@ module Bento
 
       def default_params
         { site_uuid: Bento.config.site_uuid }
-      end
-
-      def validate_email(email)
-        raise ArgumentError, 'Email is required' if email.nil? || email.empty?
-      end
-
-      def validate_author(author)
-        raise ArgumentError, 'Author is required' if author.nil? || author.empty?
-        # Additional validation can be implemented based on system requirements
       end
     end
   end

--- a/lib/bento/resources/emails.rb
+++ b/lib/bento/resources/emails.rb
@@ -36,7 +36,7 @@ module Bento
 
       def send_bulk(emails)
         raise ArgumentError, 'Emails must be an array' unless emails.is_a?(Array)
-        emails.each { |email| validate_email(email) }
+        emails.each { |email| validate_email(email[:to]); validate_email(email[:from]) }
 
         payload = { emails: emails }.to_json
         response = client.post("api/v1/batch/emails?#{URI.encode_www_form(default_params)}", payload)

--- a/lib/bento/resources/events.rb
+++ b/lib/bento/resources/events.rb
@@ -1,9 +1,11 @@
 module Bento
   class Events
     class << self
+      include Bento::Validators::Base
+      include Bento::Validators::EventValidators
       # Track an event
       # Usage examples:
-      # 
+      #
       # Basic event:
       # Bento::Events.track(email: 'test@test.com', type: '$completed_onboarding')
       #
@@ -69,60 +71,6 @@ module Bento
 
       def default_params
         { site_uuid: Bento.config.site_uuid }
-      end
-
-      def validate_email(email)
-        raise ArgumentError, 'Email is required' if email.nil? || email.empty?
-        raise ArgumentError, 'Invalid email format' unless email =~ /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
-      end
-
-      def validate_type(type)
-        raise ArgumentError, 'Type is required' if type.nil? || type.empty?
-      end
-
-      def validate_fields(fields)
-        raise ArgumentError, 'Fields must be a hash' unless fields.is_a?(Hash)
-      end
-
-      def validate_details(details)
-        raise ArgumentError, 'Details must be a hash' unless details.is_a?(Hash)
-        validate_unique(details[:unique]) if details.key?(:unique)
-        validate_value(details[:value]) if details.key?(:value)
-        validate_cart(details[:cart]) if details.key?(:cart)
-      end
-
-      def validate_unique(unique)
-        raise ArgumentError, 'Unique must be a hash' unless unique.is_a?(Hash)
-        raise ArgumentError, 'Unique key is required' unless unique.key?(:key)
-      end
-
-      def validate_value(value)
-        raise ArgumentError, 'Value must be a hash' unless value.is_a?(Hash)
-        raise ArgumentError, 'Currency is required in value' unless value.key?(:currency)
-        raise ArgumentError, 'Amount is required in value' unless value.key?(:amount)
-      end
-
-      def validate_cart(cart)
-        raise ArgumentError, 'Cart must be a hash' unless cart.is_a?(Hash)
-        validate_cart_items(cart[:items]) if cart.key?(:items)
-      end
-
-      def validate_cart_items(items)
-        raise ArgumentError, 'Cart items must be an array' unless items.is_a?(Array)
-        items.each do |item|
-          raise ArgumentError, 'Cart item must be a hash' unless item.is_a?(Hash)
-          raise ArgumentError, 'Product SKU is required in cart item' unless item.key?(:product_sku)
-          raise ArgumentError, 'Product name is required in cart item' unless item.key?(:product_name)
-          raise ArgumentError, 'Quantity is required in cart item' unless item.key?(:quantity)
-        end
-      end
-
-      def validate_event(event)
-        raise ArgumentError, 'Event must be a hash' unless event.is_a?(Hash)
-        validate_email(event[:email])
-        validate_type(event[:type])
-        validate_fields(event[:fields]) if event.key?(:fields)
-        validate_details(event[:details]) if event.key?(:details)
       end
     end
   end


### PR DESCRIPTION
## Observation

One of the observation is that the classes under `lib/bento/resources/` should be responsible for one thing. So if it is the `events.rb` class, it should be responsible for tracking events. If it is the `emails.rb` class, then it should be responsible for sending emails.

Right now, they are also managing their own set of validations. 

## Problems

I see 2 potential issues with that:
1.) As the code base grows, and more validations and resources are added, there could be repeated validations across more resources. For example: the `validate_email` is needed by both `emails.rb` and `events.rb`. And one of them is doing pattern matching while the other is not. This should be one method, that is used everywhere email validations are needed.

2.) If the validations are not DRYed out, then it could be confusing in the future to make changes to it. and chances of missing out changes in either validations at all places or in resources.

For these 2 reasons, I think, validations should be extracted out.

## Design Thinking for the solution:

1.) Since there is at least 1 validation that is common right now and may be more in the future, there should be a common class which wraps up the validation.

2.) Need validation classes for specific resources as well, so that logic is not shared by other resources when not needed to. For ex: `validate_cart_items` is needed by `events` but not by `emails`. So it should not be exposed to such validations. For that reason we should have resource specific validations as well.
