### PR TITLE
Fixed reek warnings

### DIFF
--- a/lib/bento/core/client.rb
+++ b/lib/bento/core/client.rb
@@ -1,4 +1,8 @@
 module Bento
+  # Client class for interacting with the Bento API.
+  # This class provides methods for making HTTP GET and POST requests to the API,
+  # handles authentication, connection errors, and response parsing.
+  # It also supports a development mode for local testing.
   class Client
     def get(endpoint)
       handle_connection_errors { parse_response(conn.get(endpoint)) }
@@ -24,7 +28,7 @@ module Bento
 
     def conn
       Faraday.new(
-        url: dev_mode? ? 'http://localhost:3000' : 'https://app.bentonow.com',
+        url: Bento.dev_mode ? 'http://localhost:3000' : 'https://app.bentonow.com',
         headers: {
           'Content-Type' => 'application/json',
           'Accept' => 'application/json',
@@ -34,14 +38,10 @@ module Bento
       )
     end
 
-    def dev_mode?
-      Bento.dev_mode || false
-    end
-
     def handle_connection_errors
       yield
-    rescue Faraday::ConnectionFailed => e
-      raise Bento::ConnectionError, "Failed to connect to the server: #{e.message}"
+    rescue Faraday::ConnectionFailed => exception
+      raise Bento::ConnectionError, "Failed to connect to the server: #{exception.message}"
     end
   end
 end

--- a/lib/bento/core/error.rb
+++ b/lib/bento/core/error.rb
@@ -1,4 +1,7 @@
 module Bento
+  # Custom error class for handling Bento API errors.
+  # This class encapsulates the HTTP response and provides
+  # a formatted error message for easier debugging and error handling.
   class Error < StandardError
     attr_reader :response
 

--- a/lib/bento/core/response.rb
+++ b/lib/bento/core/response.rb
@@ -1,4 +1,8 @@
 module Bento
+  # Represents a response from the Bento API.
+  # This class encapsulates the API response data and provides
+  # methods to check the status of the operation (success or failure)
+  # based on the number of successful and failed results.
   class Response
     attr_reader :results, :failed
 


### PR DESCRIPTION
Fixed these reek warnings:
* IrresponsibleModule: Bento::Client has no descriptive comment [https://github.com/troessner/reek/blob/v6.3.0/docs/Irresponsible-Module.md]
* UncommunicativeVariableName: Bento::Client#handle_connection_errors has the variable name 'e' [https://github.com/troessner/reek/blob/v6.3.0/docs/Uncommunicative-Variable-Name.md]
* UtilityFunction: Bento::Client#dev_mode? doesn't depend on instance state (maybe move it to another class?) [https://github.com/troessner/reek/blob/v6.3.0/docs/Utility-Function.md]
* IrresponsibleModule: Bento::Response has no descriptive comment [https://github.com/troessner/reek/blob/v6.3.0/docs/Irresponsible-Module.md]
* IrresponsibleModule: Bento::Error has no descriptive comment [https://github.com/troessner/reek/blob/v6.3.0/docs/Irresponsible-Module.md]

