### PR TITLE
Add explicit Base64 require and dependency

### DIFF
--- a/bento-sdk.gemspec
+++ b/bento-sdk.gemspec
@@ -14,11 +14,12 @@ Gem::Specification.new do |spec|
   spec.email = "support@Bentonow.com"
   spec.homepage = "https://github.com/bentonow/bento-ruby-sdk"
   spec.license = "MIT"
-  
+
   spec.required_ruby_version = ">= 2.6"
 
   # Used in gem
   spec.add_dependency 'faraday', ">= 0.14"
+  spec.add_dependency 'base64', '~> 0.1'
 
   # Used in specs
   spec.add_development_dependency 'bundler', '>= 1.15'

--- a/lib/bento-sdk.rb
+++ b/lib/bento-sdk.rb
@@ -15,6 +15,7 @@ require "bento/sdk/configuration"
 
 require 'forwardable'
 require 'faraday'
+require 'base64'
 
 module Bento
   class Error < StandardError; end


### PR DESCRIPTION
The `require` is needed regardless, but the gem dependency will be needed in newer versions of Ruby