### PR TITLE
Delegate Bento methods to config accessor instead of ivar

### DIFF
--- a/lib/bento-sdk.rb
+++ b/lib/bento-sdk.rb
@@ -47,11 +47,11 @@ module Bento
     extend Forwardable
 
     # User configurable options
-    def_delegators :@config, :site_uuid, :site_uuid=
-    def_delegators :@config, :publishable_key, :publishable_key=
-    def_delegators :@config, :secret_key, :secret_key=
-    def_delegators :@config, :log_level, :log_level=
-    def_delegators :@config, :dev_mode, :dev_mode=
+    def_delegators :config, :site_uuid, :site_uuid=
+    def_delegators :config, :publishable_key, :publishable_key=
+    def_delegators :config, :secret_key, :secret_key=
+    def_delegators :config, :log_level, :log_level=
+    def_delegators :config, :dev_mode, :dev_mode=
 
     def config
       @config ||= Bento::Configuration.new


### PR DESCRIPTION
It's possible there's a reason we don't want these methods to install a default configuration by side-effect. But barring that, the delegation errors we get when calling these methods in the absence of a configuration are confusing and not super helpful.

If we want to avoid setting @config implicitly, I can pitch a different PR